### PR TITLE
fix(ErrorResponse): HTML to JSON error representation

### DIFF
--- a/src/main/java/util/ErrorResponse.java
+++ b/src/main/java/util/ErrorResponse.java
@@ -1,83 +1,102 @@
 package util;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+
 import javax.servlet.http.HttpServletResponse;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
 import enums.ResponseMessage;
 
 public class ErrorResponse {
+	private static final Gson gson = new Gson();
+	
+	private static void sendErrorResponseMessage(HttpServletResponse response, String message) {
+		try {
+			response.setContentType("application/json");
+			response.setCharacterEncoding("UTF-8");
+			PrintWriter writer = response.getWriter();
+			writer.print(getErrorResponseMessageJson(message));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+    }
+	
+	private static void sendErrorResponseMessage(HttpServletResponse response, ResponseMessage message) {
+		sendErrorResponseMessage(response, message.getMessage());
+	}
     
-    public static void sendBadRequestStatus(HttpServletResponse response, String message) {
-        try {
-            response.sendError(HttpServletResponse.SC_BAD_REQUEST, message);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+    private static String getErrorResponseMessageJson(String message) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("message", message);
+        return gson.toJson(jsonObject);
     }
-
-    public static void sendNotFoundStatus(HttpServletResponse response, String message) {
-        try {
-            response.sendError(HttpServletResponse.SC_NOT_FOUND, message);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+    
+    
+    
+    public static void sendBadRequestStatus(HttpServletResponse response, ResponseMessage message) {
+		response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+		sendErrorResponseMessage(response, message);
     }
-
-    public static void sendConflictStatus(HttpServletResponse response, String message) {
-        try {
-            response.sendError(HttpServletResponse.SC_CONFLICT, message);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+    
+    public static void sendNotFoundStatus(HttpServletResponse response, ResponseMessage message) {
+    	response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+		sendErrorResponseMessage(response, message);
+    }
+    
+    public static void sendConflictStatus(HttpServletResponse response, ResponseMessage message) {
+    	response.setStatus(HttpServletResponse.SC_CONFLICT);
+		sendErrorResponseMessage(response, message);
     }
 
     public static void sendInternalServerError(HttpServletResponse response, String message) {
-        try {
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, message);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+    	response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		sendErrorResponseMessage(response, message);
     }
+    
 
 
-    public static void sendCurrencyCodeIsMissingError(HttpServletResponse reponse) {
-        sendBadRequestStatus(reponse, ResponseMessage.CURRENCY_CODE_IS_MISSING.getMessage());
+    public static void sendCurrencyCodeIsMissingError(HttpServletResponse response) {
+        sendBadRequestStatus(response, ResponseMessage.CURRENCY_CODE_IS_MISSING);
     }
 
     public static void sendCurrencyIsNotFoundInListError(HttpServletResponse response) {
-        sendNotFoundStatus(response, ResponseMessage.CURRENCY_IS_NOT_FOUND_IN_DB.getMessage());
+        sendNotFoundStatus(response, ResponseMessage.CURRENCY_IS_NOT_FOUND_IN_DB);
     }
 
     public static void sendCurrencyParametersAreNotValidError(HttpServletResponse response) {
-        sendBadRequestStatus(response, ResponseMessage.CURRENCY_PARAMETERS_ARE_NOT_VALID.getMessage());
+        sendBadRequestStatus(response, ResponseMessage.CURRENCY_PARAMETERS_ARE_NOT_VALID);
     }
 
     public static void sendCurrencyIsAlreadyExistsError(HttpServletResponse response) {
-        sendConflictStatus(response, ResponseMessage.CURRENCY_IS_ALREADY_EXIST.getMessage());
+        sendConflictStatus(response, ResponseMessage.CURRENCY_IS_ALREADY_EXIST);
     }
 
 
 
     public static void sendExchangeRateParametersAreNotValidError(HttpServletResponse response) {
-        sendBadRequestStatus(response, ResponseMessage.EXCHANGE_RATE_PARAMETERS_ARE_NOT_VALID.getMessage());
+        sendBadRequestStatus(response, ResponseMessage.EXCHANGE_RATE_PARAMETERS_ARE_NOT_VALID);
     }
 
     public static void sendExchangeRateIsInListError(HttpServletResponse response) {
-        sendConflictStatus(response, ResponseMessage.EXCHANGE_RATE_IS_ALREADY_IN_LIST.getMessage());
+        sendConflictStatus(response, ResponseMessage.EXCHANGE_RATE_IS_ALREADY_IN_LIST);
     }
 
     public static void sendInvalidPathError(HttpServletResponse response) {
-        sendBadRequestStatus(response, ResponseMessage.EXCHANGE_RATE_CODES_ARE_MISSING.getMessage());
+        sendBadRequestStatus(response, ResponseMessage.EXCHANGE_RATE_CODES_ARE_MISSING);
     }
 
-    public static void sendExchangeRateNotFoundError(HttpServletResponse response) {
-        sendNotFoundStatus(response, ResponseMessage.EXCHANGE_RATE_IS_NOT_FOUND.getMessage());
+	public static void sendExchangeRateNotFoundError(HttpServletResponse response) {
+        sendNotFoundStatus(response, ResponseMessage.EXCHANGE_RATE_IS_NOT_FOUND);
     }
 
     public static void sendExchangeRateIsEmptyError(HttpServletResponse response) {
-        sendBadRequestStatus(response, ResponseMessage.EXCHANGE_RATE_IS_EMPTY.getMessage());
+        sendBadRequestStatus(response, ResponseMessage.EXCHANGE_RATE_IS_EMPTY);
     }
 
     public static void sendExchangeRateIsNotANumberError(HttpServletResponse response) {
-        sendBadRequestStatus(response, ResponseMessage.EXCHANGE_RATE_IS_NOT_A_NUMBER.getMessage());
+        sendBadRequestStatus(response, ResponseMessage.EXCHANGE_RATE_IS_NOT_A_NUMBER);
     }
 }


### PR DESCRIPTION
Previously, all responses with errors were transmitted to the client using HTML. This commit translates the error representation into JSON format in accordance with the terms of reference