### PR TITLE
fix(Utilities): fix bug in ExchangeRateServlet

### DIFF
--- a/src/main/java/util/Utilities.java
+++ b/src/main/java/util/Utilities.java
@@ -51,7 +51,7 @@ public class Utilities {
     }
 
     public static boolean isValidExchangeRatePath(String pathInfo) {
-        return (!areEmpty(pathInfo) || !pathInfo.equals("/") || pathInfo.length() == 7);
+        return (!areEmpty(pathInfo) && !pathInfo.equals("/") && pathInfo.length() == 7);
     }
 
     public static void deleteEntityById(String query, Long id, DatabaseManager dbManager) {


### PR DESCRIPTION
If one of the parameters was not filled in in the request to get the exchange rate, the StringIndexOutOfBoundsException error occurred. This commit fixes this error